### PR TITLE
[RC-4890] Updated OkHttp to fix ClassCastException crash on Android

### DIFF
--- a/Naxam.Mapbox.Platform.Droid/Naxam.Mapbox.Platform.Droid.csproj
+++ b/Naxam.Mapbox.Platform.Droid/Naxam.Mapbox.Platform.Droid.csproj
@@ -100,9 +100,6 @@
     <PackageReference Include="Naxam.MapboxSdkGeojson.Droid">
       <Version>3.4.0</Version>
     </PackageReference>
-    <PackageReference Include="Naxam.Mapbox.Droid">
-      <Version>6.4.0.1</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CustomInfoWindowAdapter.cs" />
@@ -145,6 +142,10 @@
     <ProjectReference Include="..\Naxam.Mapbox.Forms\Naxam.Mapbox.Forms.csproj">
       <Project>{82660F7E-7012-4994-87AE-B98513B4FEB4}</Project>
       <Name>Naxam.Mapbox.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Mapbox-Native\mapbox-android-binding\Naxam.Mapbox.Droid\Naxam.Mapbox.Droid.csproj">
+      <Project>{974F61D3-E549-4659-AF38-1A1A77C5F86F}</Project>
+      <Name>Naxam.Mapbox.Droid</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Naxam.Mapbox.Platform.Droid/packages.config
+++ b/Naxam.Mapbox.Platform.Droid/packages.config
@@ -14,7 +14,7 @@
   <package id="Naxam.Mapzen.Lost.Droid" version="3.0.4" targetFramework="monoandroid81" />
   <package id="NETStandard.Library" version="2.0.1" targetFramework="monoandroid81" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="monoandroid81" />
-  <package id="Square.OkHttp3" version="3.8.1" targetFramework="monoandroid81" />
+  <package id="Square.OkHttp3" version="3.10.0" targetFramework="monoandroid81" />
   <package id="Square.OkIO" version="1.13.0" targetFramework="monoandroid81" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid70" />

--- a/Naxam.Mapbox.Platform.iOS/Naxam.Mapbox.Platform.iOS.csproj
+++ b/Naxam.Mapbox.Platform.iOS/Naxam.Mapbox.Platform.iOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.props" Condition="Exists('..\..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.props')" />
   <Import Project="..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.props')" />
   <Import Project="..\packages\Xamarin.Forms.3.1.0.697729\build\netstandard2.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.3.1.0.697729\build\netstandard2.0\Xamarin.Forms.props')" />
   <PropertyGroup>
@@ -90,16 +91,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -138,4 +139,5 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.3.1.0.697729\build\netstandard2.0\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.3.1.0.697729\build\netstandard2.0\Xamarin.Forms.targets')" />
   <Import Project="..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.3.3.0.912540\build\Xamarin.Forms.targets')" />
 </Project>

--- a/Naxam.Mapbox.Platform.iOS/Naxam.Mapbox.Platform.iOS.csproj
+++ b/Naxam.Mapbox.Platform.iOS/Naxam.Mapbox.Platform.iOS.csproj
@@ -101,9 +101,6 @@
     <Reference Include="Xamarin.Forms.Xaml">
       <HintPath>..\..\packages\Xamarin.Forms.3.3.0.912540\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
-    <Reference Include="Naxam.Mapbox.iOS">
-      <HintPath>..\..\packages\Naxam.Mapbox.iOS.4.3.0.3\lib\Xamarin.iOS10\Naxam.Mapbox.iOS.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -128,6 +125,10 @@
     <ProjectReference Include="..\Naxam.Mapbox.Forms\Naxam.Mapbox.Forms.csproj">
       <Project>{82660F7E-7012-4994-87AE-B98513B4FEB4}</Project>
       <Name>Naxam.Mapbox.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Mapbox-Native\mapbox-ios-binding\Naxam.Mapbox.iOS\Naxam.Mapbox.iOS.csproj">
+      <Project>{682AEE9E-B4F4-4BED-8D14-23582E4992FE}</Project>
+      <Name>Naxam.Mapbox.iOS</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Naxam.Mapbox.Platform.iOS/packages.config
+++ b/Naxam.Mapbox.Platform.iOS/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Naxam.Mapbox.iOS" version="4.3.0.3" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="3.3.0.912540" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
Pulled the code for the native binding libraries into submodules and referenced submodules instead of nuget packages as needed. Updated OkHttp to 3.10.0 to fix ClassCastException.